### PR TITLE
Soluciona el envío de headers en las peticiones POST

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "front-starter-project",
+	"name": "mueveteapp",
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "svelte-kit dev",

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,9 @@
+export const getHeaders = (request) => {
+    return new Headers({
+        "accept": "*/*",
+        "host": request.headers.get("host"),
+        "content-type": "application/json",
+        "connection": "keep-alive",
+        "cookie": request.headers.get("cookie")
+    });
+}

--- a/src/routes/api/usuarios/login.js
+++ b/src/routes/api/usuarios/login.js
@@ -1,6 +1,7 @@
+import { getHeaders } from "$lib/utils";
+
 export const post = async ({ request, locals }) => {
-    const headers = new Headers(request.headers);
-    headers.set("content-type", "application/json");
+    const headers = getHeaders(request);
     const body = await request.json();
     const apiURI = locals.apiURI;
 
@@ -13,6 +14,7 @@ export const post = async ({ request, locals }) => {
     if (response.ok) {
         return {
             status: 200,
+            headers: response.headers
         }
     } else {
         return {

--- a/src/routes/api/usuarios/registro.js
+++ b/src/routes/api/usuarios/registro.js
@@ -1,6 +1,7 @@
+import { getHeaders } from "$lib/utils";
+
 export const post = async ({ request, locals }) => {
-    const headers = new Headers(request.headers);
-    headers.set("Content-Type", "application/json");
+    const headers = getHeaders(request);
     const body = await request.json();
     const apiURI = locals.apiURI;
 
@@ -13,6 +14,7 @@ export const post = async ({ request, locals }) => {
     if (response.ok) {
         return {
             status: 201,
+            headers: response.headers,
             body: await response.json()
         }
     } else {

--- a/src/routes/usuarios/login.svelte
+++ b/src/routes/usuarios/login.svelte
@@ -16,7 +16,7 @@ const handleLogin = async () => {
     });
 
     if (response.ok) {
-        goto("/")
+        goto("/");
     } else {
         error = await response.json()
     }

--- a/src/routes/usuarios/registro.svelte
+++ b/src/routes/usuarios/registro.svelte
@@ -27,7 +27,7 @@ const handleDatosUsuario = async (event) => {
     });
 
     if (response.ok) {
-        goto("/usuarios/login")
+        goto("/usuarios/login");
     } else {
         error = await response.json();
     }


### PR DESCRIPTION
En los despliegues de Heroku las peticiones POST no se realizaban correctamente, ya que no se estaban enviando correctamente los headers en las peticiones realizadas por los fetch implícitos. Se implementa una función que construye unos headers óptimos para la realización de la petición, pasando los datos que deben recibirse en la petición.