### PR TITLE
Fix borrar artículos y eventos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 				"@sveltejs/adapter-node": "^1.0.0-next.78",
 				"cookie": "^0.5.0",
 				"dotenv": "^16.0.1",
-				"downloadjs": "^1.4.7",
 				"pdf-lib": "^1.17.1"
 			},
 			"devDependencies": {
@@ -451,11 +450,6 @@
 			"engines": {
 				"node": ">=12"
 			}
-		},
-		"node_modules/downloadjs": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
-			"integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
 		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
@@ -2548,11 +2542,6 @@
 			"version": "16.0.1",
 			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
 			"integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
-		},
-		"downloadjs": {
-			"version": "1.4.7",
-			"resolved": "https://registry.npmjs.org/downloadjs/-/downloadjs-1.4.7.tgz",
-			"integrity": "sha512-LN1gO7+u9xjU5oEScGFKvXhYf7Y/empUIIEAGBs1LzUq/rg5duiDrkuH5A2lQGd5jfMOb9X9usDa2oVXwJ0U/Q=="
 		},
 		"emoji-regex": {
 			"version": "8.0.0",

--- a/src/lib/ArticuloContainer.svelte
+++ b/src/lib/ArticuloContainer.svelte
@@ -34,7 +34,9 @@ $: markup = marked(articulo.cuerpo);
     </main>
     {#if articulo.referencia}
     <footer class="row">
-        <p>Referencia web: <a target="_blank" href="{articulo.referencia}">{articulo.referencia}</a></p>
+        <div class="col">
+            <p><a target="_blank" href="{articulo.referencia}">Referencia web</a></p>
+        </div>
     </footer>
     {/if}
 </article>

--- a/src/lib/ArticuloList.svelte
+++ b/src/lib/ArticuloList.svelte
@@ -26,14 +26,14 @@ const borrarArticulo = async () => {
                 <div class="btn-group" role="group">
                     <a href={`/articulos/${articulo._id}`} class="btn btn-primary">Ir al artículo</a>
                     <a href={`/articulos/form/${articulo._id}`} class="btn btn-secondary">Editar</a>
-                    <button data-toggle="modal" data-target="#borrarModal" class="btn btn-secondary">Eliminar</button>
+                    <button data-toggle="modal" data-target="#borrar{articulo._id}" class="btn btn-secondary">Eliminar</button>
                 </div>
             </div>
         </div>
     </div>
 </div>
 
-<div class="modal fade" id="borrarModal" tabindex="-1" role="dialog">
+<div class="modal fade" id="borrar{articulo._id}" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/src/lib/ArticuloList.svelte
+++ b/src/lib/ArticuloList.svelte
@@ -42,6 +42,9 @@ const borrarArticulo = async () => {
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
+            <div class="modal-body">
+                <p>Se va a eliminar el artículo "{articulo.titulo}"</p>
+            </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                 <button on:click={borrarArticulo} type="button" class="btn btn-danger" data-dismiss="modal">Sí, eliminar</button>

--- a/src/lib/EventoList.svelte
+++ b/src/lib/EventoList.svelte
@@ -50,6 +50,9 @@ const borrarEvento = async () => {
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
+            <div class="modal-body">
+                <p>Se va a eliminar el evento "{evento.nombre}"</p>
+            </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancelar</button>
                 <button on:click={borrarEvento} type="button" class="btn btn-danger" data-dismiss="modal">Sí, eliminar</button>

--- a/src/lib/EventoList.svelte
+++ b/src/lib/EventoList.svelte
@@ -33,7 +33,7 @@ const borrarEvento = async () => {
                     <a href={`/eventos/${evento._id}`} class="btn btn-primary">Ir a evento</a>
                     {#if $session.user.rol == "admin"}
                     <a href={`/eventos/form/${evento._id}`} class="btn btn-secondary">Editar</a>
-                    <button data-toggle="modal" data-target="#borrarModal" class="btn btn-secondary">Eliminar</button>
+                    <button data-toggle="modal" data-target="#borrar{evento._id}" class="btn btn-secondary">Eliminar</button>
                     {/if}
                 </div>
             </div>
@@ -41,7 +41,7 @@ const borrarEvento = async () => {
     </div>
 </div>
 
-<div class="modal fade" id="borrarModal" tabindex="-1" role="dialog">
+<div class="modal fade" id="borrar{evento._id}" tabindex="-1" role="dialog">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
             <div class="modal-header">

--- a/src/routes/api/articulos/borrar.js
+++ b/src/routes/api/articulos/borrar.js
@@ -12,9 +12,8 @@ export const del = async ({ request, locals }) => {
     });
 
     if (response.ok) {
-        response.headers.set("location", "/admin/articulos");
         return {
-            status: 302,
+            status: 201,
             headers: response.headers
         }
     } else {

--- a/src/routes/api/eventos/borrar.js
+++ b/src/routes/api/eventos/borrar.js
@@ -12,9 +12,8 @@ export const del = async ({ request, locals }) => {
     });
 
     if (response.ok) {
-        response.headers.set("location", "/admin/eventos");
         return {
-            status: 302,
+            status: 201,
             headers: response.headers
         }
     } else {


### PR DESCRIPTION
Se han corregido un par de aspectos que ocurrían en el borrado tanto de artículos como de eventos, en el panel de administración.

- Eliminar el recurso correcto: se eliminaba siempre el primero de la lista por conflicto de id en etiquetas HTML.
- Se retornaba de forma errónea tras el borrado, lo que no permitía refrescar la lista de recursos.